### PR TITLE
fix(goreleaser): remove deprecated conflicts_with formula

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,13 +46,11 @@ changelog:
       - "^test:"
 
 homebrew_casks:
-  - name: kommit 
+  - name: kommit
     repository:
       owner: madflow
       name: homebrew-kommit
     homepage: https://github.com/madflow/kommit
-    conflicts:
-      - formula: kommit
     commit_author:
       name: madflow
     skip_upload: auto


### PR DESCRIPTION
Remove the deprecated 'formula' key from the conflicts section in .goreleaser.yaml as it is no longer supported and causes a deprecation warning.

## Changes
- Removed the deprecated  section with  from .goreleaser.yaml
- This fixes the warning: 'Calling conflicts_with formula: is deprecated! There is no replacement.'

## Why this change
The  key in the  section for homebrew_casks is deprecated in goreleaser with no replacement available. Since a cask and formula with the same name naturally conflict, explicitly declaring this conflict is unnecessary.